### PR TITLE
Large build number

### DIFF
--- a/src/main/java/com/cdancy/artifactory/rest/features/BuildApi.java
+++ b/src/main/java/com/cdancy/artifactory/rest/features/BuildApi.java
@@ -37,6 +37,6 @@ public interface BuildApi {
    @Path("/build/promote/{buildName}/{buildNumber}")
    @Fallback(RequestStatusFromError.class)
    @POST
-   RequestStatus promote(@PathParam("buildName") String buildName, @PathParam("buildNumber") int buildNumber,
+   RequestStatus promote(@PathParam("buildName") String buildName, @PathParam("buildNumber") long buildNumber,
                          @BinderParam(BindToJsonPayload.class) PromoteBuildOptions promoteBuildOptions);
 }

--- a/src/test/java/com/cdancy/artifactory/rest/features/BuildApiMockTest.java
+++ b/src/test/java/com/cdancy/artifactory/rest/features/BuildApiMockTest.java
@@ -60,6 +60,31 @@ public class BuildApiMockTest extends BaseArtifactoryMockTest {
         }
     }
 
+    public void testPromoteBuildLargeBuildNumber() throws Exception {
+        MockWebServer server = mockArtifactoryJavaWebServer();
+
+        String payload = payloadFromResource("/build-promote.json");
+        server.enqueue(new MockResponse().setBody(payload).setResponseCode(200));
+        ArtifactoryApi jcloudsApi = api(server.getUrl("/"));
+        BuildApi api = jcloudsApi.buildApi();
+        try {
+            String name = "MyBuildPlan";
+            long buildNumber = 1516010677327l;
+
+            String sourceRepo = "dev-repo";
+            String targetRepo = "release-repo";
+            PromoteBuildOptions options = PromoteBuildOptions.create("promote", "error promoted", "BuildUser", null, false, sourceRepo, targetRepo, true, true, false, null, null, true);
+            RequestStatus promoteStatus = api.promote(name, buildNumber, options);
+            assertNotNull(promoteStatus);
+            assertTrue(promoteStatus.errors().size() == 0);
+            assertTrue(promoteStatus.messages().size() == 0);
+            assertSent(server, "POST", "/api/build/promote/MyBuildPlan/1516010677327", MediaType.APPLICATION_JSON);
+        } finally {
+            jcloudsApi.close();
+            server.shutdown();
+        }
+    }
+
     public void testPromoteBuildNonExistent() throws Exception {
         MockWebServer server = mockArtifactoryJavaWebServer();
 


### PR DESCRIPTION
In our environment the build number appears to be a timestamp (ms).
This fixes by allowing a long for the build number instead of an integer.