### PR TITLE
Expose targetTag for PromoteImage

### DIFF
--- a/src/main/java/com/cdancy/artifactory/rest/domain/docker/PromoteImage.java
+++ b/src/main/java/com/cdancy/artifactory/rest/domain/docker/PromoteImage.java
@@ -31,13 +31,16 @@ public abstract class PromoteImage {
    @Nullable
    public abstract String tag();
 
+    @Nullable
+    public abstract String targetTag();
+
    public abstract boolean copy();
 
    PromoteImage() {
    }
 
-   @SerializedNames({ "targetRepo", "dockerRepository", "tag", "copy" })
-   public static PromoteImage create(String targetRepo, String dockerRepository, String tag, boolean copy) {
-      return new AutoValue_PromoteImage(targetRepo, dockerRepository, tag, copy);
-   }
+    @SerializedNames({ "targetRepo", "dockerRepository", "tag", "targetTag", "copy" })
+    public static PromoteImage create(String targetRepo, String dockerRepository, String tag, String targetTag, boolean copy) {
+        return new AutoValue_PromoteImage(targetRepo, dockerRepository, tag, targetTag, copy);
+    }
 }

--- a/src/test/java/com/cdancy/artifactory/rest/features/DockerApiLiveTest.java
+++ b/src/test/java/com/cdancy/artifactory/rest/features/DockerApiLiveTest.java
@@ -49,14 +49,14 @@ public class DockerApiLiveTest extends BaseArtifactoryApiLiveTest {
 
     @Test
     public void testPromote() {
-        PromoteImage dockerPromote = PromoteImage.create(dockerRepoPromoted, dockerImage, dockerTag, true);
+        PromoteImage dockerPromote = PromoteImage.create(dockerRepoPromoted, dockerImage, dockerTag, null,true);
         boolean success = api().promote(dockerRepo, dockerPromote);
         assertTrue(success);
     }
 
     @Test
     public void testPromoteNonExistentImage() {
-        PromoteImage dockerPromote = PromoteImage.create(dockerRepoPromoted, dockerImage, "0009", false);
+        PromoteImage dockerPromote = PromoteImage.create(dockerRepoPromoted, dockerImage, "0009", null,false);
         boolean success = api().promote(dockerRepo, dockerPromote);
         assertFalse(success);
     }

--- a/src/test/java/com/cdancy/artifactory/rest/features/DockerApiMockTest.java
+++ b/src/test/java/com/cdancy/artifactory/rest/features/DockerApiMockTest.java
@@ -46,7 +46,7 @@ public class DockerApiMockTest extends BaseArtifactoryMockTest {
       ArtifactoryApi jcloudsApi = api(server.getUrl("/"));
       DockerApi api = jcloudsApi.dockerApi();
       try {
-          PromoteImage dockerPromote = PromoteImage.create("docker-promoted", "library/artifactory", "latest", false);
+          PromoteImage dockerPromote = PromoteImage.create("docker-promoted", "library/artifactory", "1.0.0","latest", false);
           boolean success = api.promote("docker-local", dockerPromote);
           assertTrue(success);
           assertSent(server, "POST", "/api/docker/docker-local/v2/promote", MediaType.TEXT_PLAIN);
@@ -64,7 +64,7 @@ public class DockerApiMockTest extends BaseArtifactoryMockTest {
         ArtifactoryApi jcloudsApi = api(server.getUrl("/"));
         DockerApi api = jcloudsApi.dockerApi();
         try {
-            PromoteImage dockerPromote = PromoteImage.create("docker-promoted", "library/artifactory", "latest", false);
+            PromoteImage dockerPromote = PromoteImage.create("docker-promoted", "library/artifactory", "latest", null, false);
             boolean success = api.promote("docker-local", dockerPromote);
             assertFalse(success);
             assertSent(server, "POST", "/api/docker/docker-local/v2/promote", MediaType.TEXT_PLAIN);

--- a/src/test/resources/docker-promote.json
+++ b/src/test/resources/docker-promote.json
@@ -1,6 +1,7 @@
 {
   "targetRepo":"docker-promoted",
   "dockerRepository":"library/artifactory",
-  "tag":"latest",
+  "tag":"1.0.0",
+  "targetTag":"latest",
   "copy":false
 }


### PR DESCRIPTION
The Docker PromteImage logic is missing the ability to set the target tag. This is required when we want to promote a CI build image like 1.0.0-1234 to a final image 1.0.0 without needing to pull, retag, and push the image.

![Screenshot from 2020-03-05 07-55-21](https://user-images.githubusercontent.com/54679517/75984051-b6601e00-5eb7-11ea-9266-48824c2bef86.png)


closes #3
