### PR TITLE
Update the project build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk8
+jdk: openjdk17
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation ('ch.qos.logback:logback-classic:1.2.10')
 }
 
-ext.compatibilityVersion = '1.8'
+ext.compatibilityVersion = JavaVersion.VERSION_11
 sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion
 
@@ -100,3 +100,11 @@ task integTest(type: Test, dependsOn: ['mockTest']) {
                         "test.artifactory.docker.tag" : "${testArtifactoryRestDockerTag}"] << authentication
 }
 
+javadoc {
+    source = sourceSets.main.allJava
+    options.with {
+        links "https://docs.oracle.com/en/java/javase/${compatibilityVersion}/docs/api"
+        links "https://google.github.io/guice/api-docs/${dependencies.guiceVersion}/javadoc/"
+        addStringOption('Xdoclint:none', '-quiet')
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bring the project up to date:

* Build with Java 17
* Source compatibility Java 11
* Gradle 7.3.3
* Fix javadoc

This should be merged after #75 as it might not build until jcenter is back on-line.
