### PR TITLE
Shadow supports Java 11, not 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk17
+jdk: openjdk11
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
As per the [shadow plugin README](https://github.com/johnrengelman/shadow), Java 17 is not supported and trying to run `publishToMavenLocal` does not work with Java 17, so downgrading travis to run with Java 11.
