### PR TITLE
Fix javadoc for Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,5 +105,6 @@ javadoc {
         links "https://docs.oracle.com/javase/${compatibilityVersion.toString().split("\\.").last()}/docs/api"
         links "https://google.github.io/guice/api-docs/${dependencies.guiceVersion}/javadoc/"
         addStringOption('Xdoclint:none', '-quiet')
+        addStringOption('source', '8')
     }
 }


### PR DESCRIPTION
PR #85 downgraded the source and target compatibility to Java 8 and that broke javadoc. This PR fixes the javadoc.